### PR TITLE
fix: add Vercel configuration for monorepo deployment

### DIFF
--- a/packages/web/buildingai-ui/package.json
+++ b/packages/web/buildingai-ui/package.json
@@ -9,6 +9,7 @@
         "postinstall": "NUXT_BUILD_SSR=true NUXT_BUILD_ENV=development nuxt prepare --dotenv ../../../.env",
         "build:ssr": "cross-env NODE_OPTIONS=--max-old-space-size=8192 NUXT_BUILD_SSR=true NUXT_BUILD_ENV=production nuxt build --dotenv ../../../.env && cross-env NUXT_BUILD_SSR=true node ../../../scripts/release.mjs",
         "generate": "cross-env NODE_OPTIONS=--max-old-space-size=8192 NUXT_BUILD_SSR=false NUXT_BUILD_ENV=production nuxt generate --dotenv ../../../.env && cross-env NUXT_BUILD_SSR=false node ../../../scripts/release.mjs",
+        "generate:vercel": "cross-env NODE_OPTIONS=--max-old-space-size=8192 NUXT_BUILD_SSR=false NUXT_BUILD_ENV=production nuxt generate",
         "dev": "NUXT_BUILD_SSR=false NUXT_BUILD_ENV=development nuxt dev --no-clear --dotenv ../../../.env",
         "start:ssr": "node .output/server/index.mjs",
         "start": "npx serve .output/public",

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://openapi.vercel.sh/vercel.json",
+    "version": 2,
+    "framework": "nuxt",
+    "installCommand": "pnpm install",
+    "buildCommand": "pnpm --filter @buildingai/buildingai-ui generate:vercel",
+    "outputDirectory": "packages/web/buildingai-ui/.output/public",
+    "rewrites": [
+        {
+            "source": "/(.*)",
+            "destination": "/index.html"
+        }
+    ]
+}


### PR DESCRIPTION
- Add vercel.json with proper build configuration for pnpm monorepo
- Add generate:vercel script that skips the release.mjs post-build step
- Use pnpm filter to run build in the correct package context
- Configure correct output directory for Nuxt static generation