### PR TITLE
feat(ai-sdk): add Eden AI as a built-in provider

### DIFF
--- a/packages/@buildingai/ai-sdk/src/providers/edenai/index.ts
+++ b/packages/@buildingai/ai-sdk/src/providers/edenai/index.ts
@@ -1,0 +1,46 @@
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import type { LanguageModelV3 } from "@ai-sdk/provider";
+
+import type { AIProvider, BaseProviderSettings, ProviderModelInfo } from "../../types";
+import { fetchProviderModels } from "../../utils/fetch-models";
+
+export interface EdenAIProviderSettings extends BaseProviderSettings {}
+
+class EdenAIProviderImpl implements AIProvider {
+    readonly id = "edenai";
+    readonly name = "Eden AI";
+
+    private baseProvider: ReturnType<typeof createOpenAICompatible>;
+    private settings: EdenAIProviderSettings;
+
+    constructor(settings: EdenAIProviderSettings = {}) {
+        this.settings = {
+            ...settings,
+            baseURL: settings.baseURL || "https://api.edenai.run/v3",
+        };
+
+        this.baseProvider = createOpenAICompatible({
+            name: "edenai",
+            baseURL: this.settings.baseURL!,
+            headers: {
+                Authorization:
+                    this.settings?.apiKey && this.settings?.apiKey.includes("Bearer ")
+                        ? this.settings.apiKey
+                        : `Bearer ${this.settings.apiKey}`,
+                ...this.settings.headers,
+            },
+        });
+    }
+
+    languageModel(modelId: string): LanguageModelV3 {
+        return this.baseProvider.languageModel(modelId);
+    }
+
+    async listModels(): Promise<ProviderModelInfo[]> {
+        return fetchProviderModels(this.settings);
+    }
+}
+
+export function edenai(settings: EdenAIProviderSettings = {}): AIProvider {
+    return new EdenAIProviderImpl(settings);
+}

--- a/packages/@buildingai/ai-sdk/src/providers/index.ts
+++ b/packages/@buildingai/ai-sdk/src/providers/index.ts
@@ -3,6 +3,7 @@ export { azure, type AzureProviderSettings } from "./azure";
 export { cohere, type CohereProviderSettings } from "./cohere";
 export { custom, type CustomProviderSettings } from "./custom";
 export { deepseek, type DeepSeekProviderSettings } from "./deepseek";
+export { edenai, type EdenAIProviderSettings } from "./edenai";
 export { giteeAi, type GiteeAIProviderSettings } from "./gitee-ai";
 export { google, type GoogleProviderSettings } from "./google";
 export { hunyuan, type HunyuanProviderSettings } from "./hunyuan";

--- a/packages/@buildingai/ai-sdk/src/registry/provider-registry.ts
+++ b/packages/@buildingai/ai-sdk/src/registry/provider-registry.ts
@@ -4,6 +4,7 @@ import {
     cohere,
     custom,
     deepseek,
+    edenai,
     giteeAi,
     google,
     hunyuan,
@@ -53,6 +54,7 @@ class ProviderRegistry {
         this.register("gitee_ai", giteeAi, "Gitee AI 魔力方舟");
         this.register("x", x, "xAI Grok 系列模型");
         this.register("openrouter", openrouter, "OpenRouter 统一接入 300+ 模型");
+        this.register("edenai", edenai, "Eden AI 欧洲 OpenAI 兼容网关");
         this.register("azure", azure, "Azure AI 服务");
         this.register("custom", custom, "自定义 OpenAI 兼容 API");
     }

--- a/packages/@buildingai/db/src/seeds/data/model-config.json
+++ b/packages/@buildingai/db/src/seeds/data/model-config.json
@@ -1,5 +1,5 @@
 {
-    "total": 19,
+    "total": 20,
     "updated_at": "2026-02-11T10:12:54.673Z",
     "configs": [
         {
@@ -19,6 +19,13 @@
         {
             "provider": "azure",
             "label": "Azure",
+            "icon_url": "",
+            "supported_model_types": ["llm"],
+            "models": []
+        },
+        {
+            "provider": "edenai",
+            "label": "Eden AI",
             "icon_url": "",
             "supported_model_types": ["llm"],
             "models": []


### PR DESCRIPTION
## What

Adds Eden AI as a built-in provider.

Eden AI is an EU-based, OpenAI-compatible LLM gateway (one API key, one endpoint, many upstream vendors). Because it speaks the OpenAI protocol, it is registered through the shared `@ai-sdk/openai-compatible` adapter, mirroring the existing Moonshot and SiliconFlow providers. No new dependency is added.

Model ids are vendor-prefixed, e.g. `openai/gpt-4o-mini`, `anthropic/claude-haiku-4-5`, `mistral/mistral-small-latest`. The provider reads its API key as a Bearer token and defaults to `https://api.edenai.run/v3` (overridable via `baseURL`). `listModels()` uses the shared `fetchProviderModels` helper against Eden AI's OpenAI-style `/v3/models` endpoint.

## Changes

- `packages/@buildingai/ai-sdk/src/providers/edenai/index.ts`: the provider (mirrors `providers/moonshot`).
- `packages/@buildingai/ai-sdk/src/providers/index.ts`: export `edenai` and its settings type.
- `packages/@buildingai/ai-sdk/src/registry/provider-registry.ts`: register `edenai`.
- `packages/@buildingai/db/src/seeds/data/model-config.json`: seed Eden AI as a built-in provider entry (empty `models`, like `azure`/`ollama`/`spark`; users add models or `listModels()` fetches them live). `total` bumped 19 -> 20.

## Testing

- `pnpm --filter @buildingai/ai-sdk check-types` (tsc) passes.
- `eslint` and `prettier --check` are clean on the changed files.
- Live: verified against the real Eden AI API with a real key, using the same code path as the provider (`createOpenAICompatible` with the Bearer header + `languageModel` + `generateText`). Three upstream vendors returned completions: `openai/gpt-4o-mini`, `anthropic/claude-haiku-4-5`, `mistral/mistral-small-latest`.

## Note

This registers and seeds Eden AI for new installs. Existing installs would additionally need a seed-sync migration (like `1778524800000-26.1.1-ai-model-seed-sync.ts`) to insert the provider row into an already-migrated database; happy to add one if you'd like it in this PR.
