### PR TITLE
feat(tools): 集成 You.com 联网搜索工具

### DIFF
--- a/packages/@buildingai/ai-toolkit/src/tools/index.ts
+++ b/packages/@buildingai/ai-toolkit/src/tools/index.ts
@@ -4,3 +4,4 @@ export * from "./openai-research.tools.js";
 export * from "./read-attached-file.tools.js";
 export * from "./request-execution-plan.tools.js";
 export * from "./weather.tools.js";
+export * from "./youcom-search.tools.js";

--- a/packages/@buildingai/ai-toolkit/src/tools/youcom-search.tools.ts
+++ b/packages/@buildingai/ai-toolkit/src/tools/youcom-search.tools.ts
@@ -1,0 +1,116 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+const YOUCOM_SEARCH_URL = "https://ydc-index.io/v1/search";
+
+interface SearchResult {
+    title: string;
+    url: string;
+    snippet: string;
+}
+
+interface YoucomSearchResponse {
+    results?: SearchResult[];
+}
+
+async function fetchJsonWithRetry(
+    url: string,
+    options?: RequestInit,
+    retries = 2,
+    timeoutMs = 15000,
+): Promise<unknown> {
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt <= retries; attempt++) {
+        try {
+            const controller = new AbortController();
+            const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+            try {
+                const response = await fetch(url, {
+                    ...options,
+                    signal: controller.signal,
+                });
+
+                if (!response.ok) {
+                    throw new Error(`HTTP_${response.status}`);
+                }
+
+                return await response.json();
+            } finally {
+                clearTimeout(timeoutId);
+            }
+        } catch (error) {
+            lastError = error;
+        }
+    }
+
+    throw lastError instanceof Error ? lastError : new Error("FETCH_FAILED");
+}
+
+export const youcomSearch = tool({
+    description:
+        "Search the web for up-to-date information using You.com Search API. Use this tool when you need to find current events, latest news, real-time data, or any information that may not be in your training data. Input should be a self-contained search query.",
+    inputSchema: z.object({
+        query: z.string().describe("The search query — be specific and include key terms"),
+        maxResults: z
+            .number()
+            .int()
+            .min(1)
+            .max(20)
+            .default(10)
+            .optional()
+            .describe("Maximum number of results to return, between 1 and 20"),
+    }),
+    needsApproval: false,
+    execute: async (input) => {
+        const apiKey = process.env.YOUCOM_API_KEY;
+
+        const payload: Record<string, unknown> = {
+            query: input.query,
+            count: input.maxResults ?? 10,
+        };
+
+        const headers: Record<string, string> = {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+        };
+        if (apiKey) {
+            headers["X-API-Key"] = apiKey;
+        }
+
+        let data: YoucomSearchResponse;
+        try {
+            data = (await fetchJsonWithRetry(
+                YOUCOM_SEARCH_URL,
+                {
+                    method: "POST",
+                    headers,
+                    body: JSON.stringify(payload),
+                },
+                2,
+                15000,
+            )) as YoucomSearchResponse;
+        } catch (error) {
+            return {
+                success: false,
+                error: `You.com Search request failed: ${error instanceof Error ? error.message : "Unknown error"
+                    }`,
+            };
+        }
+
+        const results = data?.results;
+        if (!results || results.length === 0) {
+            return { success: true, results: [], message: "No results found" };
+        }
+
+        return {
+            success: true,
+            results: results.slice(0, input.maxResults ?? 10).map((r) => ({
+                title: r.title,
+                url: r.url,
+                snippet: r.snippet,
+            })),
+        };
+    },
+});

--- a/packages/api/src/modules/ai/agents/services/agent-chat-completion.service.ts
+++ b/packages/api/src/modules/ai/agents/services/agent-chat-completion.service.ts
@@ -18,6 +18,7 @@ import {
     createReadAttachedFileTool,
     createRequestExecutionPlanTool,
     getWeather,
+    youcomSearch,
 } from "@buildingai/ai-toolkit/tools";
 import {
     parseFile,
@@ -726,6 +727,7 @@ export class AgentChatCompletionService {
         const tools: Record<string, Tool> = { ...mcpTools };
 
         tools.getWeather = getWeather;
+        tools.youcomSearch = youcomSearch;
 
         if (documentContents?.length) {
             tools.read_attached_file = createReadAttachedFileTool({ documents: documentContents });
@@ -818,6 +820,7 @@ export class AgentChatCompletionService {
             "getWeather",
             "read_attached_file",
             "request_execution_plan",
+            "youcomSearch",
         ]);
 
         return Object.fromEntries(


### PR DESCRIPTION
### 描述

为 BuildingAI 平台添加 You.com 联网搜索工具，供 AI 智能体在对话中实时检索网络信息。

### 改动内容

- packages/@buildingai/ai-toolkit/src/tools/youcom-search.tools.ts：新增搜索工具文件，使用 Vercel ai SDK 的 tool() 函数和 zod schema 定义输入参数（query 必填，maxResults 可选 1-20，默认 10），内部调用 fetchJsonWithRetry 向 POST https://ydc-index.io/v1/search 发起请求，API Key 通过 YOUCOM_API_KEY 环境变量配置（可选），needsApproval 设为 false
- packages/@buildingai/ai-toolkit/src/tools/index.ts：新增 youcom-search.tools.js 导出
- packages/api/src/modules/ai/agents/services/agent-chat-completion.service.ts：在导入列表中加入 youcomSearch，在 buildTools() 方法中将 youcomSearch 注册到工具集合，在 skipApproval 集合中加入 "youcomSearch" 使其在启用审批流程时也无需确认即可执行

### 影响范围

- 仅作为内置工具新增，不影响现有 MCP 集成、智能体逻辑或其他内置工具
- 无需新增数据库表或配置项，YOUCOM_API_KEY 为可选环境变量