### PR TITLE
fix: 修复README中失效的Star历史图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ the [Q&A forum](https://www.buildingai.cc/question).
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=BidingCC/BuildingAI&type=Date)](https://www.star-history.com/#BidingCC/BuildingAI&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=BidingCC/BuildingAI&type=Date)](https://star-history.dera.page/#BidingCC/BuildingAI&Date)
 
 ## Privacy Policy
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -79,7 +79,7 @@ docker compose up -d
 
 ## Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=BidingCC/BuildingAI&type=Date)](https://www.star-history.com/#BidingCC/BuildingAI&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=BidingCC/BuildingAI&type=Date)](https://star-history.dera.page/#BidingCC/BuildingAI&Date)
 
 ## 隐私政策
 


### PR DESCRIPTION
当前项目README中的Star历史图表已失效，原因是GitHub的Star数据接口受限导致无法正常加载。本次更新将英文版与中文版README中的Star历史图表链接替换为可正常工作的新地址，使图表恢复展示。